### PR TITLE
Injected the correct httpClient instead of a builder.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -54,7 +54,7 @@ final class Client
         $httpClient = (new Builder())
             ->withEndpoint($endpoint)
             ->withCredentials($username, $password)
-        ;
+            ->createConfiguredHttpClient();
 
         return new self($httpClient);
     }


### PR DESCRIPTION
Dear alcohol,

When using the following convenient shortcut, a fatal error occurred.

`$apiClient = Alcohol\GoAnywhere\Client::create($endpoint, $username, $password);`

The Client constructor expects a HttpClient Interface but got the Builder instead.